### PR TITLE
Fix Integrated Dynamics facades cannot be crafted

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/appliedenergistics2/removal.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/appliedenergistics2/removal.js
@@ -7,7 +7,7 @@ onEvent('recipes', (event) => {
     //Disable an item completely.
     itemsToRemoveAE.forEach((entry) => {
         event.remove({ output: entry });
-        event.remove({ input: entry });
+        event.remove({ input: entry, id: '/appliedenergistics2/' });
     });
 
     //Remove a recipe by id


### PR DESCRIPTION
## Reproduction Steps
1. Place **Facade - None** and **Stone** into the crafting table.

## Expected Behavior
- **Facade - Stone** is crafted.

## Actual Behavior
- No item can be crafted.

## Explanation of PR Content
The recipe for facades with various items is the one recipe. Removing any recipe for the facade will remove all facade crafting recipes.
This PR restricts recipe removal in the AE2 scope. Other possible solutions include excluding recipes from ID.
